### PR TITLE
Add tar_scm config and template for git cache

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,7 @@ default['open-build-service']['source_service']['workdir']['tmpfs']['size'] = ni
 default['open-build-service']['source_service']['servicedir'] = nil
 default['open-build-service']['source_service']['serviceroot'] = nil
 default['open-build-service']['source_service']['user'] = 'obsrun'
+default['open-build-service']['source_service']['tar_scm']['cachedirectory'] = ""
 
 
 default['open-build-service']['worker']['repo_servers'] = ""

--- a/recipes/source_server.rb
+++ b/recipes/source_server.rb
@@ -34,3 +34,34 @@ service 'obssigner' do
   action [:enable, :start]
   only_if { !get_keyfile.to_s.empty? }
 end
+
+template 'tar_scm' do
+  path '/etc/obs/services/tar_scm'
+  source "tar_scm.erb"
+  owner "root"
+  group "root"
+  mode "0644"
+end
+
+if node['open-build-service']['source_service']['tar_scm']['cachedirectory'] != ""
+  directory node['open-build-service']['source_service']['tar_scm']['cachedirectory'] do
+    owner 'obsrun'
+    group 'obsrun'
+    mode '0755'
+  end
+  directory node['open-build-service']['source_service']['tar_scm']['cachedirectory'] + '/repo' do
+    owner 'obsrun'
+    group 'obsrun'
+    mode '0755'
+  end
+  directory node['open-build-service']['source_service']['tar_scm']['cachedirectory'] + '/repourl' do
+    owner 'obsrun'
+    group 'obsrun'
+    mode '0755'
+  end
+  directory node['open-build-service']['source_service']['tar_scm']['cachedirectory'] + '/incoming' do
+    owner 'obsrun'
+    group 'obsrun'
+    mode '0755'
+  end
+end

--- a/templates/default/tar_scm.erb
+++ b/templates/default/tar_scm.erb
@@ -1,0 +1,13 @@
+#
+# Define a cache directory here to avoid repeating downloads of the
+# same file. This works on the server and on the client side.
+#
+# Note that this file can be overridden with per-user config placed
+# in ~/.obs/tar_scm
+#
+# WARNING: you need to create three directories inside, when changing from default:
+#          mkdir -p repo{,url} incoming
+#
+<% if !node['open-build-service']['source_service']['tar_scm']['cachedirectory'].empty? -%>
+CACHEDIRECTORY="<%= node['open-build-service']['source_service']['tar_scm']['cachedirectory'] %>"
+<% end -%>


### PR DESCRIPTION
tar_scm supports caching git repositories to save time and bandwidth,
but it is disabled by default.
Add the required directories creation logic to the source server
recipe, and a template and configuration for the cache directory.